### PR TITLE
Fix Airflow Doc Ingestion Task Incorrect Typing Error (#283)

### DIFF
--- a/airflow/include/tasks/extract/airflow_docs.py
+++ b/airflow/include/tasks/extract/airflow_docs.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import re
+import urllib.parse
+
 import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+from weaviate.util import generate_uuid5
 
 from include.tasks.extract.utils.html_utils import get_internal_links
 
@@ -27,4 +33,26 @@ def extract_airflow_docs(docs_base_url: str) -> list[pd.DataFrame]:
 
     all_links = get_internal_links(docs_base_url, exclude_literal=exclude_docs)
 
-    return all_links
+    docs_url_parts = urllib.parse.urlsplit(docs_base_url)
+    docs_url_base = f"{docs_url_parts.scheme}://{docs_url_parts.netloc}"
+    # make sure we didn't accidentally pickup any unrelated links in recursion
+    non_doc_links = {link if docs_url_base not in link else "" for link in all_links}
+    docs_links = all_links - non_doc_links
+
+    df = pd.DataFrame(docs_links, columns=["docLink"])
+
+    df["html_content"] = df["docLink"].apply(lambda x: requests.get(x).content)
+
+    df["content"] = df["html_content"].apply(
+        lambda x: str(BeautifulSoup(x, "html.parser").find(class_="body", role="main"))
+    )
+    df["content"] = df["content"].apply(lambda x: re.sub("¶", "", x))
+
+    df["sha"] = df["content"].apply(generate_uuid5)
+    df["docSource"] = "apache/airflow/docs"
+    df.reset_index(drop=True, inplace=True)
+
+    # column order matters for uuid generation
+    df = df[["docSource", "sha", "content", "docLink"]]
+
+    return [df]


### PR DESCRIPTION
### Description
- See https://github.com/astronomer/ask-astro/issues/282 for details of why the error occurs. This won't be explained again in this PR.
- TL;DR: A previous refactor PR deleted parts where we convert a set of URLs for airflow docs into a list of dataframes containing the actual docs.

### Technical Changes
- Added previous incorrectly deleted code back (from this PR https://github.com/astronomer/ask-astro/pull/237/files#diff-a9a4a2183823324d52b3b700e73457392b9117a8fdbd252621e8d4d2f10b2ec1, and this file
https://github.com/astronomer/ask-astro/blob/f0967a60ac8e37b8d3885940d636b2b381d36e4e/airflow/include/tasks/extract/airflow_docs.py)

### Tests
- Previously

![image](https://github.com/astronomer/ask-astro/assets/26350341/63d5aa0b-0744-462b-a79a-926ff68da673)
- Now

![image](https://github.com/astronomer/ask-astro/assets/26350341/7ffe2c7e-f4ff-4634-a994-a21189ba0876)


closes #282